### PR TITLE
Functional operators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,11 @@ calc.go
 y.output
 rubi
 test_rubi
+
+.idea/expreduce.iml
+
+.idea/modules.xml
+
+.idea/vcs.xml
+
+.idea/workspace.xml

--- a/expreduce/builtin_comparison.go
+++ b/expreduce/builtin_comparison.go
@@ -106,7 +106,7 @@ func getComparisonDefinitions() (defs []Definition) {
 		},
 	})
 	defs = append(defs, Definition{
-		Name:         "NumberQ",
+		Name: "NumberQ",
 		legacyEvalFn: singleParamQEval(numberQ),
 	})
 	defs = append(defs, Definition{
@@ -121,11 +121,16 @@ func getComparisonDefinitions() (defs []Definition) {
 			if len(this.Parts) != 3 {
 				return this
 			}
-			if !numberQ(this.Parts[1]) || !numberQ(this.Parts[2]) {
+
+			a := NewExpression([]Ex{&Symbol{"System`N"}, this.Parts[1]}).Eval(es)
+			b := NewExpression([]Ex{&Symbol{"System`N"}, this.Parts[2]}).Eval(es)
+
+			if !numberQ(a) || !numberQ(b) {
 				return this
 			}
+
 			// Less
-			if ExOrder(this.Parts[1], this.Parts[2]) == 1 {
+			if ExOrder(a, b) == 1 {
 				return &Symbol{"System`True"}
 			}
 			return &Symbol{"System`False"}
@@ -140,11 +145,15 @@ func getComparisonDefinitions() (defs []Definition) {
 			if len(this.Parts) != 3 {
 				return this
 			}
-			if !numberQ(this.Parts[1]) || !numberQ(this.Parts[2]) {
+
+			a := NewExpression([]Ex{&Symbol{"System`N"}, this.Parts[1]}).Eval(es)
+			b := NewExpression([]Ex{&Symbol{"System`N"}, this.Parts[2]}).Eval(es)
+
+			if !numberQ(a) || !numberQ(b) {
 				return this
 			}
 			// Greater
-			if ExOrder(this.Parts[1], this.Parts[2]) == -1 {
+			if ExOrder(a, b) == -1 {
 				return &Symbol{"System`True"}
 			}
 			return &Symbol{"System`False"}
@@ -159,15 +168,19 @@ func getComparisonDefinitions() (defs []Definition) {
 			if len(this.Parts) != 3 {
 				return this
 			}
-			if !numberQ(this.Parts[1]) || !numberQ(this.Parts[2]) {
+
+			a := NewExpression([]Ex{&Symbol{"System`N"}, this.Parts[1]}).Eval(es)
+			b := NewExpression([]Ex{&Symbol{"System`N"}, this.Parts[2]}).Eval(es)
+
+			if !numberQ(a) || !numberQ(b) {
 				return this
 			}
 			// Less
-			if ExOrder(this.Parts[1], this.Parts[2]) == 1 {
+			if ExOrder(a, b) == 1 {
 				return &Symbol{"System`True"}
 			}
 			// Equal
-			if ExOrder(this.Parts[1], this.Parts[2]) == 0 {
+			if ExOrder(a, b) == 0 {
 				return &Symbol{"System`True"}
 			}
 			return &Symbol{"System`False"}
@@ -182,15 +195,19 @@ func getComparisonDefinitions() (defs []Definition) {
 			if len(this.Parts) != 3 {
 				return this
 			}
-			if !numberQ(this.Parts[1]) || !numberQ(this.Parts[2]) {
+
+			a := NewExpression([]Ex{&Symbol{"System`N"}, this.Parts[1]}).Eval(es)
+			b := NewExpression([]Ex{&Symbol{"System`N"}, this.Parts[2]}).Eval(es)
+
+			if !numberQ(a) || !numberQ(b) {
 				return this
 			}
 			// Greater
-			if ExOrder(this.Parts[1], this.Parts[2]) == -1 {
+			if ExOrder(a, b) == -1 {
 				return &Symbol{"System`True"}
 			}
 			// Equal
-			if ExOrder(this.Parts[1], this.Parts[2]) == 0 {
+			if ExOrder(a, b) == 0 {
 				return &Symbol{"System`True"}
 			}
 			return &Symbol{"System`False"}

--- a/expreduce/builtin_functional.go
+++ b/expreduce/builtin_functional.go
@@ -1,6 +1,8 @@
 package expreduce
 
-import "math/big"
+import (
+	"math/big"
+)
 
 func getFunctionalDefinitions() (defs []Definition) {
 	defs = append(defs, Definition{
@@ -47,6 +49,186 @@ func getFunctionalDefinitions() (defs []Definition) {
 			return this.Parts[2]
 		},
 	})
+	defs = append(defs, Definition{
+		Name: "FoldList",
+		legacyEvalFn: func(this *Expression, es *EvalState) Ex {
+			if len(this.Parts) != 4 {
+				return this
+			}
+
+			f := this.Parts[1]
+			first := this.Parts[2]
+			values, nonAtomic := this.Parts[3].(*Expression)
+
+			if !nonAtomic {
+				return this
+			}
+
+			if len(values.Parts) < 2 {
+				return first
+			}
+
+			toReturn := NewExpression([]Ex{&Symbol{"System`List"}})
+
+			expr := NewExpression([]Ex{
+				f,
+				first,
+				values.Parts[1],
+			})
+
+			toReturn.Parts = append(toReturn.Parts, expr);
+
+			for i:= 2; i < len(values.Parts); i++ {
+				expr = NewExpression([]Ex{
+					f,
+					expr,
+					values.Parts[i],
+				})
+
+				toReturn.Parts = append(toReturn.Parts, expr)
+			}
+
+			return toReturn
+		},
+	})
+	defs = append(defs, Definition{Name: "Fold"})
+	defs = append(defs, Definition{
+		Name: "NestList",
+		legacyEvalFn: func(this *Expression, es *EvalState) Ex {
+			if len(this.Parts) != 4 {
+				return this
+			}
+
+			f := this.Parts[1]
+			expr := this.Parts[2]
+			nInt, isInteger := this.Parts[3].(*Integer)
+			n := nInt.Val.Int64()
+
+			if !isInteger || n < 0 {
+				return this
+			}
+
+			toReturn := NewExpression([]Ex{&Symbol{"System`List"}, expr})
+
+			for i := int64(1); i <= n; i++ {
+				expr = NewExpression([]Ex {
+					f,
+					expr,
+				})
+
+				toReturn.Parts = append(toReturn.Parts, expr)
+			}
+
+			return toReturn
+		},
+	})
+	defs = append(defs, Definition{Name: "Nest"})
+	defs = append(defs, Definition{
+		Name: "NestWhileList",
+		legacyEvalFn: func(this *Expression, es *EvalState) Ex {
+			if len(this.Parts) < 4 || len(this.Parts) > 7 {
+				return this
+			}
+
+			f := this.Parts[1]
+			expr := this.Parts[2]
+			test := this.Parts[3]
+
+			m := int64(1)
+			if len(this.Parts) > 4 {
+				mInt, isInteger := this.Parts[4].(*Integer)
+				mSymbol, isSymbol := this.Parts[4].(*Symbol)
+				if isInteger {
+					m = mInt.Val.Int64()
+					if m < 0 {
+						return this
+					}
+				} else if isSymbol {
+					if mSymbol.IsEqual(&Symbol{"System`All"}, &es.CASLogger) == "EQUAL_TRUE" {
+						m = -1
+					} else {
+						return this
+					}
+				} else {
+					return this
+				}
+			}
+
+			max := int64(-1)
+			if len(this.Parts) > 5  {
+				maxInt, isInteger := this.Parts[5].(*Integer)
+				maxSymbol, isSymbol := this.Parts[5].(*Symbol)
+				if isInteger {
+					max = maxInt.Val.Int64()
+					if maxInt.Val.Int64() < 0 {
+						return this
+					}
+				} else if isSymbol {
+					if maxSymbol.IsEqual(&Symbol{"System`Infinity"}, &es.CASLogger) == "EQUAL_TRUE" {
+						max = -1
+					} else {
+						return this
+					}
+				} else {
+					return this
+				}
+			}
+
+			n := int64(0)
+			if len(this.Parts) > 6 {
+				bonusIterationsInt, isInteger := this.Parts[6].(*Integer)
+				if isInteger && bonusIterationsInt.Val.Int64() >= int64(0) {
+					n = bonusIterationsInt.Val.Int64()
+				}
+			}
+
+			evaluated := []Ex{expr.DeepCopy().Eval(es)}
+			toReturn := NewExpression([]Ex{&Symbol{"System`List"}, expr})
+
+			isequal := "EQUAL_TRUE"
+			cont := isequal == "EQUAL_TRUE"
+			for i := int64(2); cont; i++ {
+				expr = NewExpression([]Ex {
+					f,
+					expr,
+				})
+				toReturn.Parts = append(toReturn.Parts, expr)
+				evaluated = append(evaluated, expr.DeepCopy().Eval(es)) // Could use a stack of length m
+
+				if i >= m {
+					testExpression := NewExpression([]Ex {test})
+					if m >= 0 {
+						testExpression.Parts = append(testExpression.Parts, evaluated[int64(len(evaluated))-m:]...)
+					} else {
+						testExpression.Parts = append(testExpression.Parts, evaluated...)
+					}
+					isequal = testExpression.Eval(es).IsEqual(&Symbol{"System`True"}, &es.CASLogger)
+					cont = isequal == "EQUAL_TRUE"
+				}
+
+				if i > max && max != -1 {
+					cont = false
+				}
+			}
+
+			if n > 0 {
+				for i := int64(0); i < n; i++ {
+					expr = NewExpression([]Ex {
+						f,
+						expr,
+					})
+					toReturn.Parts = append(toReturn.Parts, expr)
+				}
+			} else {
+				toReturn.Parts = toReturn.Parts[:int64(len(toReturn.Parts))+n]
+			}
+
+			return toReturn
+		},
+	})
+	defs = append(defs, Definition{Name: "NestWhile"})
+	defs = append(defs, Definition{Name: "FixedPointList"})
+	defs = append(defs, Definition{Name: "FixedPoint"})
 	defs = append(defs, Definition{
 		Name: "Array",
 		legacyEvalFn: func(this *Expression, es *EvalState) Ex {

--- a/expreduce/builtin_functional.go
+++ b/expreduce/builtin_functional.go
@@ -64,11 +64,11 @@ func getFunctionalDefinitions() (defs []Definition) {
 				return this
 			}
 
-			if len(values.Parts) < 2 {
-				return first
-			}
+			toReturn := NewExpression([]Ex{values.Parts[0], first})
 
-			toReturn := NewExpression([]Ex{&Symbol{"System`List"}})
+			if len(values.Parts) < 2 {
+				return toReturn
+			}
 
 			expr := NewExpression([]Ex{
 				f,

--- a/expreduce/resources/functional.m
+++ b/expreduce/resources/functional.m
@@ -77,10 +77,8 @@ Tests`FoldList = {
         ESameTest[{1, f[1, 2], f[f[1, 2], 3]}, FoldList[f, 1, {2, 3}]],
         ESameTest[{1, f[1, 2], f[f[1, 2], 3]}, FoldList[f, {1, 2, 3}]],
         (* ESameTest[{1, f[1, 2], f[f[1, 2], 3]}, FoldList[f][{1, 2, 3}]], *)
-        ESameTest[{1, f[1, 2], f[f[1, 2], 3]}, FoldList[f][1, {2, 3}]],
         ESameTest[h[e1, f[e1, e2], f[f[e1, e2], e3], f[f[f[e1, e2], e3], e4]], FoldList[f, e1, h[e2, e3, e4]]],
         ESameTest[{h}, FoldList[f, h, {}]]
-        EComment["Known problem: FoldList[f, , {1}] ? this is because Null is not handled correctly. Try evaluating e.g. f[,]"]
     ]
 }
 
@@ -94,10 +92,8 @@ Tests`Fold = {
         ESameTest[f[f[1, 2], 3], Fold[f, 1, {2, 3}]],
         ESameTest[f[f[1, 2], 3], Fold[f, {1, 2, 3}]],
         (* ESameTest[f[f[1, 2], 3], Fold[f][{1, 2, 3}]], *)
-        ESameTest[f[f[1, 2], 3], Fold[f][1, {2, 3}]],
         ESameTest[f[f[f[e1, e2], e3], e4], Fold[f, e1, h[e2, e3, e4]]],
         ESameTest[h, Fold[f, h, {}]]
-        EComment["Known problem: Fold[f, , {1}] ? this is because Null is not handled correctly. Try evaluating e.g. f[,]"]
     ]
 }
 
@@ -159,7 +155,7 @@ Tests`FixedPointList = {
     ]
 }
 
-FixedPoint::usage = "`FixedPointList[f, expr]` applies `f` to `expr` until `UnsameQ` applied to the two most recent results
+FixedPoint::usage = "`FixedPoint[f, expr]` applies `f` to `expr` until `UnsameQ` applied to the two most recent results
 returns False."
 FixedPoint[f_, expr_] := Last[NestWhileList[f, expr, UnsameQ, 2]]
 Tests`FixedPoint = {

--- a/expreduce/sameq.go
+++ b/expreduce/sameq.go
@@ -23,7 +23,12 @@ func IsSameQ(a Ex, b Ex, cl *CASLogger) bool {
 			// https://stackoverflow.com/questions/46136886/comparing-floats-by-ignoring-last-bit-in-golang
 			aVal, _ := aFlt.Val.Float64()
 			bVal, _ := bFlt.Val.Float64()
-			return almostEqual(aVal, bVal)
+
+			if math.IsInf(aVal, 0) || math.IsInf(bVal, 0) {
+				return a.IsEqual(b, cl) == "EQUAL_TRUE"
+			} else {
+				return almostEqual(aVal, bVal)
+			}
 		} else {
 			return a.IsEqual(b, cl) == "EQUAL_TRUE"
 		}

--- a/expreduce/sameq.go
+++ b/expreduce/sameq.go
@@ -1,8 +1,10 @@
 package expreduce
 
+import "math"
+
 func IsSameQ(a Ex, b Ex, cl *CASLogger) bool {
-	_, aIsFlt := a.(*Flt)
-	_, bIsFlt := b.(*Flt)
+	aFlt, aIsFlt := a.(*Flt)
+	bFlt, bIsFlt := b.(*Flt)
 	_, aIsInteger := a.(*Integer)
 	_, bIsInteger := b.(*Integer)
 	_, aIsString := a.(*String)
@@ -16,11 +18,24 @@ func IsSameQ(a Ex, b Ex, cl *CASLogger) bool {
 
 	if (aIsFlt && bIsFlt) || (aIsString && bIsString) || (aIsInteger && bIsInteger) || (aIsSymbol && bIsSymbol) || (aIsRational && bIsRational) {
 		// a and b are identical raw types
-		return a.IsEqual(b, cl) == "EQUAL_TRUE"
+		if aIsFlt && bIsFlt {
+			// This is important, without it e.g. NestWhileList[(# + 3/#)/2 &, 1.0, UnsameQ, 2] never converges
+			// https://stackoverflow.com/questions/46136886/comparing-floats-by-ignoring-last-bit-in-golang
+			aVal, _ := aFlt.Val.Float64()
+			bVal, _ := bFlt.Val.Float64()
+			return almostEqual(aVal, bVal)
+		} else {
+			return a.IsEqual(b, cl) == "EQUAL_TRUE"
+		}
 	} else if aIsExpression && bIsExpression {
 		return a.Hash() == b.Hash()
 	}
 
 	// This should never happen
 	return false
+}
+
+func almostEqual(a, b float64) bool {
+	ai, bi := int64(math.Float64bits(a)), int64(math.Float64bits(b))
+	return a == b || -1 <= ai-bi && ai-bi <= 1
 }


### PR DESCRIPTION
New operators: 

- `FoldList`
- `Fold`
- `NestList`
- `Nest`
- `NestWhileList`
- `NestWhile`
- `FixedPointList`
- `FixedPoint`

Fixed problem with UnsameQ. Consider a problem such as this:

    FixedPoint[(# + 2/# )/2 &, 1.0]

It converges to the square root of 2, approximately 1.41421. `FixedPoint` stops when `UnsameQ[most recent, second most recent]` is `False`. If `UnsameQ` require an exact match like before the iteration may go on forever for this type of problems, so what Mathematica does (according to the documentation for `SameQ`) is to allow the last bit to be different. With the change made to `UnsameQ` these types of problems can now be solved as in Mathematica.

Fixed problem with comparison operators. E.g. `Log[100] > 0` would not evaluate before, which is inconvenient. When Mathematica's comparison operators encounter exact expressions like this they try to ascertain what the numerical comparison would result in, which is more convenient. The update applies `N` to arguments used in comparisons.